### PR TITLE
Add capability to use connection strings from app/web.config and azure cloud config

### DIFF
--- a/NLog.AzureAppendBlob.Test/NLog.AzureAppendBlob.Test.csproj
+++ b/NLog.AzureAppendBlob.Test/NLog.AzureAppendBlob.Test.csproj
@@ -32,6 +32,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.WindowsAzure.Configuration, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.3.2.1\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.WindowsAzure.Storage, Version=5.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\WindowsAzure.Storage.5.0.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
       <Private>True</Private>
@@ -55,7 +59,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/NLog.AzureAppendBlob.Test/packages.config
+++ b/NLog.AzureAppendBlob.Test/packages.config
@@ -4,6 +4,7 @@
   <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net4" />
   <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net4" />
   <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net4" />
+  <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.1" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net4" />
   <package id="NLog" version="3.1.0.0" targetFramework="net4" />
   <package id="System.Spatial" version="5.6.4" targetFramework="net4" />

--- a/NLog.AzureAppendBlob/AzureAppendBlobTarget.cs
+++ b/NLog.AzureAppendBlob/AzureAppendBlobTarget.cs
@@ -20,6 +20,7 @@ namespace NLog.AzureAppendBlob
 		[RequiredParameter]
 		public Layout BlobName { get; set; }
 
+		private ConfigManager _configManager;
 		private CloudBlobClient _client;
 		private CloudBlobContainer _container;
 		private CloudAppendBlob _blob;
@@ -28,7 +29,9 @@ namespace NLog.AzureAppendBlob
 		{
 			base.InitializeTarget();
 
-			_client = CloudStorageAccount.Parse(ConnectionString)
+			_configManager = new ConfigManager(ConnectionString);
+
+			_client = CloudStorageAccount.Parse(_configManager.GetStorageAccountConnectionString())
 			                             .CreateCloudBlobClient();
 		}
 

--- a/NLog.AzureAppendBlob/ConfigManager.cs
+++ b/NLog.AzureAppendBlob/ConfigManager.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.Azure;
+using System.Configuration;
+
+namespace NLog.AzureAppendBlob
+{
+	public class ConfigManager
+	{
+		private readonly string _connectionStringKey;
+
+		public ConfigManager(string connectionStringKey)
+		{
+			_connectionStringKey = connectionStringKey;
+		}
+
+		public string GetStorageAccountConnectionString()
+		{
+			//First, check cloud service config
+			var connectionStringValue = CloudConfigurationManager.GetSetting(_connectionStringKey);
+
+			if (!string.IsNullOrEmpty(connectionStringValue))
+				return connectionStringValue;
+
+			//No cloud config setting found, check connection local config
+			var connectionString = ConfigurationManager.ConnectionStrings[_connectionStringKey];
+
+			if (connectionString != null)
+				connectionStringValue = connectionString.ConnectionString;
+
+			//No matching connection string found using the value specified as a key,
+			// use as actual connection string
+			return connectionStringValue;
+		}
+	}
+}
+

--- a/NLog.AzureAppendBlob/NLog.AzureAppendBlob.csproj
+++ b/NLog.AzureAppendBlob/NLog.AzureAppendBlob.csproj
@@ -30,6 +30,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.WindowsAzure.Configuration, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.3.2.1\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.WindowsAzure.Storage, Version=5.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\WindowsAzure.Storage.5.0.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
       <Private>True</Private>
@@ -39,11 +43,13 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AzureAppendBlobTarget.cs" />
+    <Compile Include="ConfigManager.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/NLog.AzureAppendBlob/packages.config
+++ b/NLog.AzureAppendBlob/packages.config
@@ -4,6 +4,7 @@
   <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net4" />
   <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net4" />
   <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net4" />
+  <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.1" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net4" />
   <package id="NLog" version="3.1.0.0" targetFramework="net4" />
   <package id="System.Spatial" version="5.6.4" targetFramework="net4" />


### PR DESCRIPTION
Adds support for using Azure portal config/settings values or other App/Web.config population methods to facilitate not storing connection strings directly in nLog config or source control. Changes were fairly minor, but it looks like my IDE settings treat spaces/tabs differently than the original source, so delta is a bit bloated.
